### PR TITLE
chore: deprecation notice for v1.x SDK

### DIFF
--- a/scrapegraph-py/pyproject.toml
+++ b/scrapegraph-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scrapegraph_py"
-version = "1.12.2"
+version = "1.12.3"
 description = "ScrapeGraph Python SDK for API"
 authors = [
     { name = "Marco Vinciguerra", email = "marco@scrapegraphai.com" },

--- a/scrapegraph-py/scrapegraph_py/async_client.py
+++ b/scrapegraph-py/scrapegraph_py/async_client.py
@@ -177,14 +177,14 @@ class AsyncClient:
         warnings.warn(
             "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
             "Please upgrade to scrapegraph-py v2.x for the new API surface. "
-            "See migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82",
+            "See migration guide: https://docs.scrapegraphai.com/transition-from-v1-to-v2",
             DeprecationWarning,
             stacklevel=2,
         )
         logger.warning(
             "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
             "Please upgrade to scrapegraph-py v2.x for the new API surface. "
-            "Migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82"
+            "Migration guide: https://docs.scrapegraphai.com/transition-from-v1-to-v2"
         )
 
         # Try to get API key from environment if not provided

--- a/scrapegraph-py/scrapegraph_py/async_client.py
+++ b/scrapegraph-py/scrapegraph_py/async_client.py
@@ -34,6 +34,7 @@ Example:
         >>> asyncio.run(main())
 """
 import asyncio
+import warnings
 from typing import Any, Dict, Optional, Callable
 
 from aiohttp import ClientSession, ClientTimeout, TCPConnector
@@ -172,6 +173,19 @@ class AsyncClient:
             retry_delay: Delay between retries in seconds
         """
         logger.info("🔑 Initializing AsyncClient")
+
+        warnings.warn(
+            "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
+            "Please upgrade to scrapegraph-py v2.x for the new API surface. "
+            "See migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        logger.warning(
+            "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
+            "Please upgrade to scrapegraph-py v2.x for the new API surface. "
+            "Migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82"
+        )
 
         # Try to get API key from environment if not provided
         if api_key is None:

--- a/scrapegraph-py/scrapegraph_py/client.py
+++ b/scrapegraph-py/scrapegraph_py/client.py
@@ -182,14 +182,14 @@ class Client:
         warnings.warn(
             "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
             "Please upgrade to scrapegraph-py v2.x for the new API surface. "
-            "See migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82",
+            "See migration guide: https://docs.scrapegraphai.com/transition-from-v1-to-v2",
             DeprecationWarning,
             stacklevel=2,
         )
         logger.warning(
             "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
             "Please upgrade to scrapegraph-py v2.x for the new API surface. "
-            "Migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82"
+            "Migration guide: https://docs.scrapegraphai.com/transition-from-v1-to-v2"
         )
 
         # Try to get API key from environment if not provided

--- a/scrapegraph-py/scrapegraph_py/client.py
+++ b/scrapegraph-py/scrapegraph_py/client.py
@@ -27,6 +27,7 @@ Example:
         ...     result = client.scrape(website_url="https://example.com")
 """
 import uuid as _uuid
+import warnings
 from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
@@ -177,6 +178,19 @@ class Client:
                             static response or callable returning a response
         """
         logger.info("🔑 Initializing Client")
+
+        warnings.warn(
+            "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
+            "Please upgrade to scrapegraph-py v2.x for the new API surface. "
+            "See migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        logger.warning(
+            "scrapegraph-py v1.x is deprecated and will be removed in a future release. "
+            "Please upgrade to scrapegraph-py v2.x for the new API surface. "
+            "Migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82"
+        )
 
         # Try to get API key from environment if not provided
         if api_key is None:


### PR DESCRIPTION
## Summary

- Adds a **deprecation warning** (`DeprecationWarning` + logger warning) on `Client` and `AsyncClient` initialization, notifying users that v1.x will be removed in a future release
- Bumps version from `1.12.2` → `1.12.3`
- Points users to the v2 migration guide: https://github.com/ScrapeGraphAI/scrapegraph-py/pull/82

## Context

The v2 API surface (see #82) introduces breaking changes with a new set of endpoints (`extract`, `search`, `scrape`, `crawl.*`, `monitor.*`, etc.). This PR ensures current v1.x users are aware of the upcoming deprecation before v2 is released on `main`.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Version bump `1.12.2` → `1.12.3` |
| `client.py` | Added `DeprecationWarning` + logger warning in `__init__` |
| `async_client.py` | Added `DeprecationWarning` + logger warning in `__init__` |

## Test plan

- [x] `Client()` initialization emits a `DeprecationWarning`
- [x] `AsyncClient()` initialization emits a `DeprecationWarning`
- [x] Logger outputs deprecation message with migration link
- [ ] Existing tests still pass (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)