### PR TITLE
chore: update default API base URL to v2-api host

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ async with AsyncScrapeGraphAI() as sgai:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SGAI_API_KEY` | Your ScrapeGraphAI API key | — |
-| `SGAI_API_URL` | Override API base URL | `https://api.scrapegraphai.com/api/v2` |
+| `SGAI_API_URL` | Override API base URL | `https://v2-api.scrapegraphai.com/api/v2` |
 | `SGAI_DEBUG` | Enable debug logging (`"1"`) | off |
 | `SGAI_TIMEOUT` | Request timeout in seconds | `120` |
 

--- a/src/scrapegraph_py/env.py
+++ b/src/scrapegraph_py/env.py
@@ -15,7 +15,7 @@ class Env:
 
     @property
     def base_url(self) -> str:
-        return os.environ.get("SGAI_API_URL") or "https://api.scrapegraphai.com/api/v2"
+        return os.environ.get("SGAI_API_URL") or "https://v2-api.scrapegraphai.com/api/v2"
 
 
 env = Env()


### PR DESCRIPTION
## Summary
- Switch the SDK's default base URL from `https://api.scrapegraphai.com/api/v2` to `https://v2-api.scrapegraphai.com/api/v2` (env.py + README).
- Users can still override via `SGAI_API_URL`.

## Test plan
- [x] Live call: `client.credits()` against the new host returns a valid `CreditsResponse`.
- [x] `uv run ruff format src tests`
- [x] `uv run ruff check src tests --fix`
- [x] `uv build`
- [x] `uv run pytest tests/ -v` (28 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)