### PR TITLE
chore(release): 2.0.1 + fix default API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ async with AsyncScrapeGraphAI() as sgai:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SGAI_API_KEY` | Your ScrapeGraphAI API key | — |
-| `SGAI_API_URL` | Override API base URL | `https://api.scrapegraphai.com/api/v2` |
+| `SGAI_API_URL` | Override API base URL | `https://v2-api.scrapegraphai.com/api/v2` |
 | `SGAI_DEBUG` | Enable debug logging (`"1"`) | off |
 | `SGAI_TIMEOUT` | Request timeout in seconds | `120` |
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ async with AsyncScrapeGraphAI() as sgai:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SGAI_API_KEY` | Your ScrapeGraphAI API key | — |
-| `SGAI_API_URL` | Override API base URL | `https://v2-api.scrapegraphai.com/api/v2` |
+| `SGAI_API_URL` | Override API base URL | `https://v2-api.scrapegraphai.com/api` |
 | `SGAI_DEBUG` | Enable debug logging (`"1"`) | off |
 | `SGAI_TIMEOUT` | Request timeout in seconds | `120` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scrapegraph-py"
-version = "2.0.0"
+version = "2.0.1"
 description = "Official Python SDK for ScrapeGraph AI API"
 readme = "README.md"
 license = "MIT"

--- a/src/scrapegraph_py/env.py
+++ b/src/scrapegraph_py/env.py
@@ -15,7 +15,7 @@ class Env:
 
     @property
     def base_url(self) -> str:
-        return os.environ.get("SGAI_API_URL") or "https://v2-api.scrapegraphai.com/api/v2"
+        return os.environ.get("SGAI_API_URL") or "https://v2-api.scrapegraphai.com/api"
 
 
 env = Env()

--- a/src/scrapegraph_py/env.py
+++ b/src/scrapegraph_py/env.py
@@ -15,7 +15,7 @@ class Env:
 
     @property
     def base_url(self) -> str:
-        return os.environ.get("SGAI_API_URL") or "https://api.scrapegraphai.com/api/v2"
+        return os.environ.get("SGAI_API_URL") or "https://v2-api.scrapegraphai.com/api/v2"
 
 
 env = Env()


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to `2.0.1` (note: `2.0.0` is burned on PyPI — never published, cannot be reused)
- Fix default API base URL in `env.py` and README: `https://v2-api.scrapegraphai.com/api/v2` → `https://v2-api.scrapegraphai.com/api`

## Context
`v2.0.0` was tagged and released on GitHub but the PyPI publish step never ran (the release pipeline's semantic-release-pypi plugin wasn't configured, and `python-publish.yml` didn't trigger because semantic-release used `GITHUB_TOKEN`, which by design doesn't fire downstream workflows). The filename `scrapegraph_py-2.0.0` is now permanently blocked on PyPI, so we ship as `2.0.1`.

## Test plan
- [x] `uv run ruff format src tests`
- [x] `uv run ruff check src tests --fix`
- [x] `uv build` (produces `scrapegraph_py-2.0.1-py3-none-any.whl`)
- [x] `uv run pytest tests/ -v` → 28 passed, 1 skipped
- [x] After merge: tag `v2.0.1` and `uv publish` manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)