### PR TITLE
docs: add Open Source vs Managed API comparison to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,33 @@
 
 Official Python SDK for the [ScrapeGraphAI API](https://scrapegraphai.com).
 
+## 🆚 Open Source vs Managed API
+
+This SDK is a client for the **managed cloud API**. ScrapeGraphAI also ships an [open-source library](https://github.com/ScrapeGraphAI/Scrapegraph-ai) you can run yourself. This table explains the difference so you can pick the right one.
+
+| | Open Source (`scrapegraphai`) | Managed API (this SDK) |
+|---|---|---|
+| **What it is** | A Python library you run yourself | A hosted cloud service you call via SDK |
+| **Where it runs** | Your own infrastructure (self-hosted) | ScrapeGraphAI cloud |
+| **LLM** | Bring your own (OpenAI, Groq, Gemini, Azure, local via Ollama) | Managed for you |
+| **Browser / JS rendering** | You configure it (Playwright) | Managed (stealth, `auto`/`fast`/`js` modes) |
+| **Proxies & anti-bot** | Your responsibility | Included |
+| **Scaling & maintenance** | Your responsibility | Fully managed |
+| **Cost model** | LLM tokens + your own infra | Pay-as-you-go credits |
+| **Auth** | Your own LLM keys | `SGAI_API_KEY` |
+| **Capabilities** | Graph pipelines (SmartScraper, Search, Speech, ScriptCreator…) | Scrape, Extract, Search, Crawl, Monitor, History |
+| **Setup effort** | More configuration | Minimal — API key + one call |
+| **License** | MIT | SDK is MIT; the API service is paid |
+
+**Choose the open-source library** if you want full control, on-prem/self-hosted data, local LLMs (Ollama), or fine-grained cost tuning — and you're happy to manage browsers, proxies and scaling yourself.
+
+**Choose the managed API** (this SDK) if you want zero infrastructure, managed JS rendering & anti-bot, built-in **Crawl** and scheduled **Monitor** jobs, and the fastest path to production — billed per credit.
+
+- Open-source library: https://github.com/ScrapeGraphAI/Scrapegraph-ai
+- Python SDK: https://github.com/ScrapeGraphAI/scrapegraph-py
+- JS/TS SDK: https://github.com/ScrapeGraphAI/scrapegraph-js
+- API docs: https://docs.scrapegraphai.com/introduction
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## What

Adds a **Open Source vs Managed API** section near the top of the README: a comparison table plus short "choose X if…" guidance, clarifying that this SDK targets the managed cloud API while `scrapegraphai` is the self-hosted open-source library.

## Why

Users frequently ask what the difference is between the self-hosted open-source library and the paid hosted API. This makes it explicit (where it runs, LLM, browser/proxy handling, scaling, cost model, capabilities, license).

## Notes

- Docs-only change, no code touched.
- The same comparison section is being added to `Scrapegraph-ai` and `scrapegraph-js` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)