### PR TITLE
fix: send a User-Agent header on every API request

### DIFF
--- a/src/scrapegraph_py/async_client.py
+++ b/src/scrapegraph_py/async_client.py
@@ -11,7 +11,8 @@ from typing import Literal
 import httpx
 from pydantic import BaseModel, TypeAdapter
 
-from .env import USER_AGENT, env
+from .client import USER_AGENT
+from .env import env
 from .schemas import (
     ApiResult,
     CrawlPagesQuery,

--- a/src/scrapegraph_py/async_client.py
+++ b/src/scrapegraph_py/async_client.py
@@ -11,7 +11,7 @@ from typing import Literal
 import httpx
 from pydantic import BaseModel, TypeAdapter
 
-from .env import env
+from .env import USER_AGENT, env
 from .schemas import (
     ApiResult,
     CrawlPagesQuery,
@@ -262,7 +262,7 @@ class AsyncScrapeGraphAI:
         self._http = httpx.AsyncClient(
             base_url=env.base_url,
             timeout=env.timeout,
-            headers={"SGAI-APIKEY": self._api_key},
+            headers={"SGAI-APIKEY": self._api_key, "User-Agent": USER_AGENT},
         )
 
         self.crawl = AsyncCrawlResource(self)
@@ -292,7 +292,7 @@ class AsyncScrapeGraphAI:
                         url,
                         json=json_body,
                         params=params,
-                        headers={"SGAI-APIKEY": self._api_key},
+                        headers={"SGAI-APIKEY": self._api_key, "User-Agent": USER_AGENT},
                     )
             else:
                 resp = await self._http.request(method, path, json=json_body, params=params)

--- a/src/scrapegraph_py/client.py
+++ b/src/scrapegraph_py/client.py
@@ -11,7 +11,7 @@ from typing import Literal
 import httpx
 from pydantic import BaseModel, TypeAdapter
 
-from .env import env
+from .env import USER_AGENT, env
 from .schemas import (
     ApiResult,
     CrawlPagesQuery,
@@ -262,7 +262,7 @@ class ScrapeGraphAI:
         self._http = httpx.Client(
             base_url=env.base_url,
             timeout=env.timeout,
-            headers={"SGAI-APIKEY": self._api_key},
+            headers={"SGAI-APIKEY": self._api_key, "User-Agent": USER_AGENT},
         )
 
         self.crawl = CrawlResource(self)
@@ -291,7 +291,7 @@ class ScrapeGraphAI:
                     url,
                     json=json_body,
                     params=params,
-                    headers={"SGAI-APIKEY": self._api_key},
+                    headers={"SGAI-APIKEY": self._api_key, "User-Agent": USER_AGENT},
                     timeout=env.timeout,
                 )
             else:

--- a/src/scrapegraph_py/client.py
+++ b/src/scrapegraph_py/client.py
@@ -6,12 +6,13 @@ import re
 import sys
 import time
 from datetime import datetime
+from importlib import metadata
 from typing import Literal
 
 import httpx
 from pydantic import BaseModel, TypeAdapter
 
-from .env import USER_AGENT, env
+from .env import env
 from .schemas import (
     ApiResult,
     CrawlPagesQuery,
@@ -44,6 +45,7 @@ from .schemas import (
 )
 
 _SERVER_TIMING_RE = re.compile(r"dur=(\d+(?:\.\d+)?)")
+USER_AGENT = f"scrapegraph-py/{metadata.version('scrapegraph-py')}"
 
 
 def _debug(label: str, data: object = None) -> None:

--- a/src/scrapegraph_py/env.py
+++ b/src/scrapegraph_py/env.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
 import os
+import platform
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("scrapegraph-py")
+except PackageNotFoundError:  # local checkout without an installed distribution
+    __version__ = "unknown"
+
+USER_AGENT = f"scrapegraph-py/{__version__} python/{platform.python_version()}"
 
 
 class Env:

--- a/src/scrapegraph_py/env.py
+++ b/src/scrapegraph_py/env.py
@@ -1,15 +1,6 @@
 from __future__ import annotations
 
 import os
-import platform
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("scrapegraph-py")
-except PackageNotFoundError:  # local checkout without an installed distribution
-    __version__ = "unknown"
-
-USER_AGENT = f"scrapegraph-py/{__version__} python/{platform.python_version()}"
 
 
 class Env:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ from scrapegraph_py import (
     ScrapeGraphAI,
     ScreenshotFormatConfig,
 )
-from scrapegraph_py.env import USER_AGENT
+from scrapegraph_py.client import USER_AGENT
 
 API_KEY = "test-sgai-key"
 BASE_URL = "https://api.scrapegraphai.com/v2"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from scrapegraph_py import (
+    AsyncScrapeGraphAI,
     FetchConfig,
     HtmlFormatConfig,
     ImagesFormatConfig,
@@ -14,6 +15,7 @@ from scrapegraph_py import (
     ScrapeGraphAI,
     ScreenshotFormatConfig,
 )
+from scrapegraph_py.env import USER_AGENT
 
 API_KEY = "test-sgai-key"
 BASE_URL = "https://api.scrapegraphai.com/v2"
@@ -482,6 +484,15 @@ class TestClientInit:
     def test_explicit_api_key(self):
         sgai = ScrapeGraphAI(api_key="explicit-key")
         assert sgai._api_key == "explicit-key"
+
+    def test_sends_user_agent(self):
+        sgai = ScrapeGraphAI(api_key=API_KEY)
+        assert sgai._http.headers["User-Agent"] == USER_AGENT
+        assert USER_AGENT.startswith("scrapegraph-py/")
+
+    def test_async_sends_user_agent(self):
+        sgai = AsyncScrapeGraphAI(api_key=API_KEY)
+        assert sgai._http.headers["User-Agent"] == USER_AGENT
 
 
 class TestCamelCaseSerialization:


### PR DESCRIPTION
## What

Both `ScrapeGraphAI` and `AsyncScrapeGraphAI` only set `SGAI-APIKEY`, so every call went out with httpx's default `User-Agent` — indistinguishable from any other httpx client on the API side.

Now each request sends:

```
User-Agent: scrapegraph-py/2.3.1
```

## Changes

- `client.py`: one module-level `USER_AGENT = f"scrapegraph-py/{metadata.version('scrapegraph-py')}"` (version read from the installed distribution, so it tracks the semantic-release bump in `pyproject.toml` automatically).
- `async_client.py`: reuses that same constant.
- Header set on the pooled `httpx.Client`/`AsyncClient` **and** on the one-off absolute-URL requests (the `base_url` branch of `_request`), so no path escapes it.
- `tests/test_client.py`: asserts both clients carry the header.

Full suite: 84 passed, 1 skipped. `ruff format`, `ruff check`, `uv build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)